### PR TITLE
changed startup shirt url to reflect your new username

### DIFF
--- a/_layouts/startup-shirts.html
+++ b/_layouts/startup-shirts.html
@@ -27,11 +27,11 @@
         </p>
       </div>
       <div class="two columns">
-        <p>A collection of startup shirts. <a href="https://github.com/scottmotte/scottmotte.github.com#startup-shirts">Claim yours</a>.</p>
+        <p>A collection of startup shirts. <a href="https://github.com/motdotla/motdotla.github.io#startup-shirts">Claim yours</a>.</p>
       </div>
       <div class="seven columns">
         <p class="text-right">
-          <a class="radius primary button small" href="https://github.com/scottmotte/scottmotte.github.com#startup-shirts">Request a shirt &rarr;</a>
+          <a class="radius primary button small" href="https://github.com/motdotla/motdotla.github.io#startup-shirts">Request a shirt &rarr;</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Presently startups shirt's pull request button links to the old repository name at your old username.

As you've changed your username and the repo's name, that 404s. This fixes it.